### PR TITLE
Reconciliation property in params

### DIFF
--- a/connect/models/param.py
+++ b/connect/models/param.py
@@ -36,8 +36,6 @@ class Param(BaseModel):
     value_choice = None  # type: Optional[List[str]]
     """ (List[str]|None) Available choices for parameter. """
 
-    # Undocumented fields (they appear in PHP SDK)
-
     title = None  # type: Optional[str]
     """ (str|None) Title for parameter. """
 
@@ -58,3 +56,6 @@ class Param(BaseModel):
 
     marketplace = None  # type: Optional[Marketplace]
     """ (:py:class:`.Marketplace` | None) Marketplace. """
+
+    reconciliation = None # type: Optional[bool]
+    """ (bool|None) Is Parameter used as reconciliation one from vendor invoices """

--- a/connect/models/param.py
+++ b/connect/models/param.py
@@ -57,5 +57,5 @@ class Param(BaseModel):
     marketplace = None  # type: Optional[Marketplace]
     """ (:py:class:`.Marketplace` | None) Marketplace. """
 
-    reconciliation = None # type: Optional[bool]
+    reconciliation = None   # type: Optional[bool]
     """ (bool|None) Is Parameter used as reconciliation one from vendor invoices """

--- a/connect/models/schemas.py
+++ b/connect/models/schemas.py
@@ -314,12 +314,12 @@ class ParamSchema(BaseSchema):
     value_error = fields.Str()
     value_choice = fields.Str(many=True)
 
-    # Undocumented fields (they appear in PHP SDK)
     title = fields.Str()
     scope = fields.Str()
     constraints = fields.Nested(ConstraintsSchema)
     value_choices = fields.Nested(ValueChoiceSchema, many=True)
     phase = fields.Str()
+    reconciliation = fields.Bool()
     events = fields.Nested(EventsSchema)
     marketplace = fields.Nested(MarketplaceSchema)
     countries = fields.Nested(CountrySchema, many=True)


### PR DESCRIPTION
Added property introduced in V19 where vendor can mark a parameter as primary one for reconciliation