### PR TITLE
fix python2.7 compatibility, unicode logging issue

### DIFF
--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -34,7 +34,7 @@ def function_log(custom_logger=None):
             custom_logger.debug('Function params: {} {}'.format(args, kwargs))
             result = func(self, *args, **kwargs)
             custom_logger.debug(
-                'Function `{}.{}` return: {}'.format(
+                u'Function `{}.{}` return: {}'.format(
                     self.__class__.__name__, func.__name__, result))
             return result
 


### PR DESCRIPTION
logger raise exception when a fullfilment contains a non-ascii symbol

WARNING; 2020-04-23 13:55:45,425; Fullfilment.logger;
fulfillment_automation:dispatch:line-132: Skipping request
PR-4463-4286-6684-001 because an exception was raised: 'ascii' codec
can't encode character u'\xe1' in position 5266: ordinal not in
range(128)