### PR TITLE
UsageFileAutomation: use product_id__in filter

### DIFF
--- a/connect/resources/usage_file_automation.py
+++ b/connect/resources/usage_file_automation.py
@@ -33,7 +33,7 @@ class UsageFileAutomation(AutomationEngine):
         """
         filters = super(UsageFileAutomation, self).filters(status, **kwargs)
         if self.config.products:
-            filters['product_id'] = ','.join(self.config.products)
+            filters['product_id__in'] = ','.join(self.config.products)
         return filters
 
     def dispatch(self, request):


### PR DESCRIPTION
when multiple products are specified in config.json all products
are added to the filter, but API doesn't accept multiple products
in `product_id` param, thus `product_id__in` should be used instead.

without the fix:
```
 INFO  ; 2020-05-19 13:08:45,756; root  ; logger:wrapper:line-33: Entering: process
 DEBUG ; 2020-05-19 13:08:45,756; root  ; logger:wrapper:line-34: Function params: () {}
 INFO  ; 2020-05-19 13:08:45,756; UsageFile.logger; base:search:line-174: Get list request with filters - {'limit': 1000, 'product_id': u'PRD-263-111-111,PRD-267-111-111'}
 INFO  ; 2020-05-19 13:08:45,757; root  ; logger:wrapper:line-33: Entering: get
 DEBUG ; 2020-05-19 13:08:45,757; root  ; logger:wrapper:line-34: Function params: () {'params': {'limit': 1000, 'product_id': u'PRD-263-111-111,PRD-267-111-111'}}
Traceback (most recent call last):
  File "/usr/bin/cloudblue-usage-files", line 7, in <module>
    rv = connector.process_usage_files()
  File "/usr/lib/python2.7/site-packages/cloudblue_connector/__init__.py", line 722, in process_usage_files
    vip.process()
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/logger/logger.py", line 35, in wrapper
    result = func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/automation_engine.py", line 30, in process
    for request in self.list(filters):
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/base.py", line 198, in list
    return self.search(filters)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/base.py", line 175, in search
    response, _ = self._api.get(params=filters)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/logger/logger.py", line 35, in wrapper
    result = func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/base.py", line 73, in get
    return self._check_and_pack_response(response)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/base.py", line 120, in _check_and_pack_response
    raise ServerError(error)
connect.exceptions.ServerError: ("{'params': None, 'errors': [u'RQL Parsing error.'], 'error_code': None}", None)
```