### PR TITLE
UsageFileAutomation: use empty dict as SubmitUsageFile action body

### DIFF
--- a/connect/exceptions.py
+++ b/connect/exceptions.py
@@ -132,7 +132,7 @@ class RejectUsageFile(UsageFileAction):
 class SubmitUsageFile(UsageFileAction):
     def __init__(self):
         # type: () -> None
-        super(SubmitUsageFile, self).__init__('Usage File Submitted', 'submit')
+        super(SubmitUsageFile, self).__init__('Usage File Submitted', 'submit', {})
 
 
 class FileCreationError(Message):


### PR DESCRIPTION
API raise 500 error when `submit` action is executed with null body

```
 INFO  ; 2020-05-19 17:42:45,724; UsageFile.logger; usage_file_automation:dispatch:line-52: Start usage file request process / ID request - UF-2019-11-6974-4362
 INFO  ; 2020-05-19 17:32:05,911; root  ; logger:wrapper:line-33: Entering: post
 DEBUG ; 2020-05-19 17:32:05,911; root  ; logger:wrapper:line-34: Function params: () {'path': 'UF-2019-11-4213-7637/submit', 'data': 'null'}
Traceback (most recent call last):
  File "/usr/bin/cloudblue-usage-files", line 7, in <module>
    rv = connector.process_usage_files()
  File "/usr/lib/python2.7/site-packages/cloudblue_connector/__init__.py", line 733, in process_usage_files
    vip.process()
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/logger/logger.py", line 35, in wrapper
    result = func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/automation_engine.py", line 31, in process
    self.dispatch(request)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/usage_file_automation.py", line 68, in dispatch
    else usage.obj))
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/logger/logger.py", line 35, in wrapper
    result = func(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/base.py", line 81, in post
    return self._check_and_pack_response(response)
  File "/usr/lib/python2.7/site-packages/connect_sdk-19.2-py2.7.egg/connect/resources/base.py", line 121, in _check_and_pack_response
    raise ServerError(error)
connect.exceptions.ServerError: ('{\'params\': None, \'errors\': [u"\'NoneType\' object does not support item assignment"], \'error_code\': None}', None)
```