### PR TITLE
CPS-82 - Fix to update_parameters

### DIFF
--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -179,12 +179,10 @@ class FulfillmentAutomation(AutomationEngine):
         :return: The server response.
         :rtype: str
         """
-        list_dict = []
-        for _ in params:
-            list_dict.append(_.__dict__ if isinstance(_, Param) else _)
+        mapped_params = [p.json for p in params if isinstance(p, Param)]
         return self._api.put(
             path=pk,
-            json={'asset': {'params': list_dict}},
+            json={'asset': {'params': mapped_params}},
         )[0]
 
     def _update_conversation_if_exists(self, conversation, request_id, obj):

--- a/connect/resources/tier_config_automation.py
+++ b/connect/resources/tier_config_automation.py
@@ -119,11 +119,8 @@ class TierConfigAutomation(AutomationEngine):
         :return: The server response.
         :rtype: str
         """
-        list_dict = []
-        for _ in params:
-            list_dict.append(_.__dict__ if isinstance(_, Param) else _)
-
+        mapped_params = [p.json for p in params if isinstance(p, Param)]
         return self._api.put(
             path=pk,
-            json={'params': list_dict},
+            json={'params': mapped_params},
         )[0]


### PR DESCRIPTION
The implementation of `update_parameters` in `FulfillmentAutomation` and `TierConfigAutomation` was not parsing parameters that contain subobjects correctly, due to the fact that the `__dict__` dunder used to convert the param to a dict is not recursive. Code has been updated to use the `json` property that models have in the SDK, that return the model with the same representation that is returned when parsed with the `json.loads` function.