### PR TITLE
Fix for AssetRequest.get_conversation

### DIFF
--- a/connect/models/asset_request.py
+++ b/connect/models/asset_request.py
@@ -6,7 +6,7 @@
 import datetime
 from typing import Union
 
-from requests.exceptions import ConnectionError
+from requests.exceptions import RequestException
 
 from .asset import Asset
 from .base import BaseModel
@@ -135,7 +135,7 @@ class AssetRequest(BaseModel):
         client = ApiClient(config, base_path='conversations')
         try:
             response, _ = client.get(params={'instance_id': self.id})
-        except ConnectionError:
+        except RequestException:
             return None
         try:
             conversations = Conversation.deserialize(response)

--- a/connect/models/asset_request.py
+++ b/connect/models/asset_request.py
@@ -6,6 +6,8 @@
 import datetime
 from typing import Union
 
+from requests.exceptions import ConnectionError
+
 from .asset import Asset
 from .base import BaseModel
 from .contract import Contract
@@ -131,7 +133,10 @@ class AssetRequest(BaseModel):
         from connect.resources.base import ApiClient
 
         client = ApiClient(config, base_path='conversations')
-        response, _ = client.get(params={'instance_id': self.id})
+        try:
+            response, _ = client.get(params={'instance_id': self.id})
+        except ConnectionError:
+            return None
         try:
             conversations = Conversation.deserialize(response)
             if conversations and conversations[0].id:


### PR DESCRIPTION
If the requests library raises an exception when trying to get the conversation for a request, this PR makes it return `None` cleanly, instead of letting the exception propagate.

Handling this exception is tricky, since it was raised outside of the developer's control, before the `process_request` method is called, so this seems like a proper way to handle this situation.