### PR TITLE
CPS-83: Added LoggerAdapter.

### DIFF
--- a/connect/logger/__init__.py
+++ b/connect/logger/__init__.py
@@ -3,11 +3,12 @@
 # This file is part of the Ingram Micro Cloud Blue Connect SDK.
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
-from .logger import function_log, logger
+from .logger import function_log, logger, LoggerAdapter
 
 # TODO add auto settings for cloud platforms
 
 __all__ = [
     'function_log',
-    'logger'
+    'logger',
+    'LoggerAdapter'
 ]

--- a/connect/logger/config.json
+++ b/connect/logger/config.json
@@ -5,7 +5,7 @@
     "formatters": {
       "single-line": {
         "class": "logging.Formatter",
-        "datefmt": "%Y-%m-%d %H:%M:%S,uuu",
+        "datefmt": "%Y-%m-%d %H:%M:%S",
         "format": "%(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line-%(lineno)d: %(message)s"
       }
     },

--- a/connect/logger/config.json
+++ b/connect/logger/config.json
@@ -5,8 +5,8 @@
     "formatters": {
       "single-line": {
         "class": "logging.Formatter",
-        "datefmt": "%Y-%m-%d %H:%M:%S",
-        "format": "%(asctime)s %(levelname)-5s %(module)s.%(funcName)s(%(lineno)d): %(message)s"
+        "datefmt": "%Y-%m-%d %H:%M:%S,uuu",
+        "format": "%(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line-%(lineno)d: %(message)s"
       }
     },
     "handlers": {

--- a/connect/logger/config.json
+++ b/connect/logger/config.json
@@ -6,7 +6,7 @@
       "single-line": {
         "class": "logging.Formatter",
         "datefmt": "%Y-%m-%d %H:%M:%S",
-        "format": "%(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line-%(lineno)d: %(message)s"
+        "format": "%(asctime)s %(levelname)-5s %(module)s.%(funcName)s(%(lineno)d): %(message)s"
       }
     },
     "handlers": {

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -28,6 +28,9 @@ class LoggerAdapter(logging.LoggerAdapter):
             kwargs
         )
 
+    def setLevel(self, level):
+        self.logger.setLevel(level)
+
 
 def function_log(custom_logger=None):
     if not custom_logger:

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -43,7 +43,7 @@ def function_log(func):
     # noinspection PyShadowingNames
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        logger.info('Entering: %s', func.__name__)
+        logger.debug('Entering: %s', func.__name__)
         logger.debug('Function params: {} {}'.format(args, kwargs))
         result = func(self, *args, **kwargs)
         logger.debug(u'Function `{}.{}` return: {}'

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -32,27 +32,14 @@ class LoggerAdapter(logging.LoggerAdapter):
         self.logger.setLevel(level)
 
 
-def function_log(custom_logger=None):
-    if not custom_logger:
-        custom_logger = logging.getLogger()
-        sformat = " %(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line" \
-                  "-%(lineno)d: %(message)s"
-        for handler in custom_logger.handlers:
-            handler.setFormatter(logging.Formatter(sformat))
-
-    # noinspection PyUnusedLocal
-    def decorator(func, **kwargs):
-        # noinspection PyShadowingNames
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):
-            custom_logger.info('Entering: %s', func.__name__)
-            custom_logger.debug('Function params: {} {}'.format(args, kwargs))
-            result = func(self, *args, **kwargs)
-            custom_logger.debug(
-                u'Function `{}.{}` return: {}'.format(
-                    self.__class__.__name__, func.__name__, result))
-            return result
-
-        return wrapper
-
-    return decorator
+def function_log(func):
+    # noinspection PyShadowingNames
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        logger.info('Entering: %s', func.__name__)
+        logger.debug('Function params: {} {}'.format(args, kwargs))
+        result = func(self, *args, **kwargs)
+        logger.debug(u'Function `{}.{}` return: {}'
+                     .format(self.__class__.__name__, func.__name__, result))
+        return result
+    return wrapper

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -21,8 +21,15 @@ class LoggerAdapter(logging.LoggerAdapter):
     def __init__(self, logger_):
         super(LoggerAdapter, self).__init__(logger_, {})
         self.prefix = None
+        self.replace_handler = None
 
     def process(self, msg, kwargs):
+        if self.replace_handler:
+            handlers_copy = self.logger.handlers[:]
+            for handler in handlers_copy:
+                if isinstance(handler, type(self.replace_handler)):
+                    self.logger.removeHandler(handler)
+                    self.logger.addHandler(self.replace_handler)
         return (
             '[%s] %s' % (self.prefix, msg) if self.prefix else msg,
             kwargs

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -17,6 +17,18 @@ dictConfig(config['logging'])
 logger = logging.getLogger()
 
 
+class LoggerAdapter(logging.LoggerAdapter):
+    def __init__(self, logger_):
+        super(LoggerAdapter, self).__init__(logger_, {})
+        self.prefix = None
+
+    def process(self, msg, kwargs):
+        return (
+            '[%s] %s' % (self.prefix, msg) if self.prefix else msg,
+            kwargs
+        )
+
+
 def function_log(custom_logger=None):
     if not custom_logger:
         custom_logger = logging.getLogger()

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -18,12 +18,13 @@ logger = logging.getLogger()
 
 
 class LoggerAdapter(logging.LoggerAdapter):
-    def __init__(self, logger_):
-        super(LoggerAdapter, self).__init__(logger_, {})
+    def __init__(self, logger_, extra=None):
+        super(LoggerAdapter, self).__init__(logger_, extra or {})
         self.prefix = None
         self.replace_handler = None
 
     def process(self, msg, kwargs):
+        msg, kwargs = super(LoggerAdapter, self).process(msg, kwargs)
         if self.replace_handler:
             handlers_copy = self.logger.handlers[:]
             for handler in handlers_copy:

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -32,7 +32,7 @@ class LoggerAdapter(logging.LoggerAdapter):
                     self.logger.removeHandler(handler)
                     self.logger.addHandler(self.replace_handler)
         return (
-            '[%s] %s' % (self.prefix, msg) if self.prefix else msg,
+            '%s %s' % (self.prefix, msg) if self.prefix else msg,
             kwargs
         )
 

--- a/connect/resources/automation_engine.py
+++ b/connect/resources/automation_engine.py
@@ -62,11 +62,11 @@ class AutomationEngine(BaseResource):
     def _set_custom_logger(self, *args):
         handlers = [copy.copy(hdlr) for hdlr in global_logger.handlers]
         log_level = global_logger.level
-        self.__class__.logger.setLevel(log_level)
-        self.__class__.logger.propagate = False
-        self.__class__.logger.handlers = handlers
-        base = " %(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line" \
-               "-%(lineno)d: %(message)s"
-        sformat = " ".join(args) + base
-        [handler.setFormatter(logging.Formatter(sformat))
-         for handler in self.__class__.logger.handlers]
+        logger = self.__class__.logger
+        logger.setLevel(log_level)
+        logger.propagate = False
+        logger.handlers = handlers
+        logger.prefix = ' - '.join(args)
+        fmt = ' %(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line-%(lineno)d: %(message)s'
+        for handler in logger.handlers:
+            handler.setFormatter(logging.Formatter(fmt))

--- a/connect/resources/automation_engine.py
+++ b/connect/resources/automation_engine.py
@@ -3,7 +3,6 @@
 # This file is part of the Ingram Micro Cloud Blue Connect SDK.
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
-import copy
 import logging
 from typing import Any, Dict, Optional
 

--- a/connect/resources/automation_engine.py
+++ b/connect/resources/automation_engine.py
@@ -67,6 +67,7 @@ class AutomationEngine(BaseResource):
         logger.propagate = False
         logger.handlers = handlers
         logger.prefix = ' - '.join(args)
-        fmt = ' %(levelname)-6s; %(asctime)s; %(name)-6s; %(module)s:%(funcName)s:line-%(lineno)d: %(message)s'
+        fmt = ' %(levelname)-6s; %(asctime)s; %(name)-6s; ' \
+              '%(module)s:%(funcName)s:line-%(lineno)d: %(message)s'
         for handler in logger.handlers:
             handler.setFormatter(logging.Formatter(fmt))

--- a/connect/resources/automation_engine.py
+++ b/connect/resources/automation_engine.py
@@ -5,9 +5,9 @@
 
 import copy
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-from connect.logger import function_log, logger as global_logger
+from connect.logger import function_log, LoggerAdapter
 from connect.models.activation_tile_response import ActivationTileResponse
 from connect.models.base import BaseModel
 from .base import BaseResource
@@ -16,19 +16,23 @@ from .template import TemplateResource
 
 class AutomationEngine(BaseResource):
     limit = 1000  # type: int
-    logger = logging.getLogger()
+
+    def __init__(self, config=None):
+        super(AutomationEngine, self).__init__(config)
+        self._current_request = None
+        self._logger_adapter = None
 
     def filters(self, status='pending', **kwargs):
         # type: (str, Dict[str, Any]) -> Dict[str, Any]
         return super(AutomationEngine, self).filters(status=status, **kwargs)
 
-    @function_log(custom_logger=logger)
+    @function_log
     def process(self, filters=None):
-        '''
-        # type: (Dict[str, Any]) -> None
-        '''
+        # # type: (Dict[str, Any]) -> None
         for request in self.list(filters):
+            self._set_current_request(request)
             self.dispatch(request)
+            self._set_current_request(None)
 
     def dispatch(self, request):
         # type: (BaseModel) -> str
@@ -39,35 +43,40 @@ class AutomationEngine(BaseResource):
         raise NotImplementedError('Please implement `{}.process_request` method'
                                   .format(self.__class__.__name__))
 
-    @function_log(custom_logger=logger)
+    @function_log
     def approve(self, pk, data):
         # type: (str, dict) -> str
         return self._api.post(path=pk + '/approve/', json=data)[0]
 
-    @function_log(custom_logger=logger)
+    @function_log
     def inquire(self, pk):
         # type: (str) -> str
         return self._api.post(path=pk + '/inquire/', json={})[0]
 
-    @function_log(custom_logger=logger)
+    @function_log
     def fail(self, pk, reason):
         # type: (str, str) -> str
         return self._api.post(path=pk + '/fail/', json={'reason': reason})[0]
 
-    @function_log(custom_logger=logger)
+    @function_log
     def render_template(self, pk, template_id):
         # type: (str, str) -> ActivationTileResponse
         return TemplateResource(self.config).render(template_id, pk)
 
-    def _set_custom_logger(self, *args):
-        handlers = [copy.copy(hdlr) for hdlr in global_logger.handlers]
-        log_level = global_logger.level
-        logger = self.__class__.logger
-        logger.setLevel(log_level)
-        logger.propagate = False
-        logger.handlers = handlers
-        logger.prefix = ' - '.join(args)
-        fmt = ' %(levelname)-6s; %(asctime)s; %(name)-6s; ' \
-              '%(module)s:%(funcName)s:line-%(lineno)d: %(message)s'
-        for handler in logger.handlers:
-            handler.setFormatter(logging.Formatter(fmt))
+    @property
+    def logger(self):
+        # type: () -> logging.LoggerAdapter
+        request_id = self._current_request.id if self._current_request else 'global'
+        name = self.__class__.__name__ + '.' + request_id
+        if not self._logger_adapter or self._logger_adapter.logger.name != name:
+            self._logger_adapter = LoggerAdapter(logging.getLogger(name))
+        return self._logger_adapter
+
+    def _set_current_request(self, request):
+        # type: (Optional[BaseModel]) -> None
+        self._current_request = request
+        self._set_logger_prefix(request)
+
+    def _set_logger_prefix(self, request):
+        # type: (Optional[BaseModel]) -> None
+        pass

--- a/connect/resources/base.py
+++ b/connect/resources/base.py
@@ -63,28 +63,28 @@ class ApiClient(object):
             lambda a, b: compat.urljoin(a + ('' if a.endswith('/') else '/'), b) if b else a,
             args)
 
-    @function_log()
+    @function_log
     def get(self, path='', **kwargs):
         # type: (str, Any) -> Tuple[str, int]
         kwargs = self._fix_request_kwargs(path, kwargs)
         response = requests.get(**kwargs)
         return self._check_and_pack_response(response)
 
-    @function_log()
+    @function_log
     def post(self, path='', **kwargs):
         # type: (str, Any) -> Tuple[str, int]
         kwargs = self._fix_request_kwargs(path, kwargs)
         response = requests.post(**kwargs)
         return self._check_and_pack_response(response)
 
-    @function_log()
+    @function_log
     def put(self, path='', **kwargs):
         # type: (str, Any) -> Tuple[str, int]
         kwargs = self._fix_request_kwargs(path, kwargs)
         response = requests.put(**kwargs)
         return self._check_and_pack_response(response)
 
-    @function_log()
+    @function_log
     def delete(self, path='', **kwargs):
         # type: (str, Any) -> Tuple[str, int]
         kwargs = self._fix_request_kwargs(path, kwargs)
@@ -168,7 +168,7 @@ class BaseResource(object):
             filters[key] = val
         return filters
 
-    @function_log()
+    @function_log
     def search(self, filters=None):
         # type: (Dict[str, Any]) -> List[Any]
         filters = filters or self.filters()

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -10,7 +10,7 @@ from deprecation import deprecated
 from typing import Optional
 
 from connect.exceptions import FailRequest, InquireRequest, SkipRequest
-from connect.logger import function_log
+from connect.logger import function_log, LoggerAdapter
 from connect.models.activation_template_response import ActivationTemplateResponse
 from connect.models.activation_tile_response import ActivationTileResponse
 from connect.models.param import Param
@@ -41,7 +41,7 @@ class FulfillmentAutomation(AutomationEngine):
     __metaclass__ = ABCMeta
     resource = 'requests'
     model_class = Fulfillment
-    logger = logging.getLogger('Fullfilment.logger')
+    logger = LoggerAdapter(logging.getLogger('Fulfillment.logger'))
 
     def filters(self, status='pending', **kwargs):
         """ Returns the default set of filters for Fulfillment request, plus any others that you
@@ -131,6 +131,9 @@ class FulfillmentAutomation(AutomationEngine):
             self.logger.warning('Skipping request {} because an exception was raised: {}'
                                 .format(request.id, ex))
             return ''
+
+        finally:
+            self._set_custom_logger()
 
     def create_request(self, request):
         """ Creates a new request. Using this method requires a provider token used as api_key

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -4,13 +4,12 @@
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
 from abc import ABCMeta
-import logging
 
 from deprecation import deprecated
 from typing import Optional
 
 from connect.exceptions import FailRequest, InquireRequest, SkipRequest
-from connect.logger import function_log, LoggerAdapter
+from connect.logger import function_log
 from connect.models.activation_template_response import ActivationTemplateResponse
 from connect.models.activation_tile_response import ActivationTileResponse
 from connect.models.asset_request import AssetRequest

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -194,6 +194,6 @@ class FulfillmentAutomation(AutomationEngine):
     def _set_logger_prefix(self, request):
         # type: (Optional[AssetRequest]) -> None
         if request:
-            self.logger.prefix = request.asset.id + ' - ' + request.id
+            self.logger.prefix = request.id
         else:
             self.logger.prefix = ''

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -13,6 +13,7 @@ from connect.exceptions import FailRequest, InquireRequest, SkipRequest
 from connect.logger import function_log, LoggerAdapter
 from connect.models.activation_template_response import ActivationTemplateResponse
 from connect.models.activation_tile_response import ActivationTileResponse
+from connect.models.asset_request import AssetRequest
 from connect.models.param import Param
 from connect.models.fulfillment import Fulfillment
 from connect.models.tier_config_request import TierConfigRequest
@@ -41,7 +42,6 @@ class FulfillmentAutomation(AutomationEngine):
     __metaclass__ = ABCMeta
     resource = 'requests'
     model_class = Fulfillment
-    logger = LoggerAdapter(logging.getLogger('Fulfillment.logger'))
 
     def filters(self, status='pending', **kwargs):
         """ Returns the default set of filters for Fulfillment request, plus any others that you
@@ -74,11 +74,9 @@ class FulfillmentAutomation(AutomationEngine):
             filters['asset.product.id__in'] = ','.join(self.config.products)
         return filters
 
-    @function_log(custom_logger=logger)
+    @function_log
     def dispatch(self, request):
         # type: (Fulfillment) -> str
-        self._set_custom_logger(request.asset.id, request.id)
-
         conversation = request.get_conversation(self.config)
 
         try:
@@ -132,9 +130,6 @@ class FulfillmentAutomation(AutomationEngine):
                                 .format(request.id, ex))
             return ''
 
-        finally:
-            self._set_custom_logger()
-
     def create_request(self, request):
         """ Creates a new request. Using this method requires a provider token used as api_key
         in the Config.
@@ -173,7 +168,7 @@ class FulfillmentAutomation(AutomationEngine):
         else:
             return None
 
-    @function_log(custom_logger=logger)
+    @function_log
     def update_parameters(self, pk, params):
         """ Sends a list of Param objects to Connect for updating.
 
@@ -196,3 +191,10 @@ class FulfillmentAutomation(AutomationEngine):
             except TypeError as ex:
                 self.logger.error('Error updating conversation for request {}: {}'
                                   .format(request_id, ex))
+
+    def _set_logger_prefix(self, request):
+        # type: (Optional[AssetRequest]) -> None
+        if request:
+            self.logger.prefix = request.asset.id + ' - ' + request.id
+        else:
+            self.logger.prefix = ''

--- a/connect/resources/tier_account_request_automation.py
+++ b/connect/resources/tier_account_request_automation.py
@@ -52,7 +52,7 @@ class TierAccountRequestAutomation:
         ):
             self.dispatch(request)
 
-    @function_log(custom_logger=logger)
+    @function_log
     def dispatch(self, request):
         result = self.process_request(request)
         if result.action == TierAccountRequestAction.ACCEPT:

--- a/connect/resources/tier_config_automation.py
+++ b/connect/resources/tier_config_automation.py
@@ -7,7 +7,7 @@ from abc import ABCMeta
 import logging
 
 from connect.exceptions import FailRequest, InquireRequest, SkipRequest
-from connect.logger import function_log
+from connect.logger import function_log, LoggerAdapter
 from connect.models.activation_template_response import ActivationTemplateResponse
 from connect.models.activation_tile_response import ActivationTileResponse
 from connect.models.param import Param
@@ -36,7 +36,7 @@ class TierConfigAutomation(AutomationEngine):
     __metaclass__ = ABCMeta
     resource = 'tier/config-requests'
     model_class = TierConfigRequest
-    logger = logging.getLogger('Tier.logger')
+    logger = LoggerAdapter(logging.getLogger('Tier.logger'))
 
     def filters(self, status='pending', **kwargs):
         """ Returns the default set of filters for Tier Config request, plus any others that you
@@ -107,6 +107,9 @@ class TierConfigAutomation(AutomationEngine):
             self.logger.warning('Skipping request {} because an exception was raised: {}'
                                 .format(request.id, ex))
             return ''
+
+        finally:
+            self._set_custom_logger()
 
         return ''
 

--- a/connect/resources/tier_config_automation.py
+++ b/connect/resources/tier_config_automation.py
@@ -4,11 +4,10 @@
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
 from abc import ABCMeta
-import logging
 from typing import Optional
 
 from connect.exceptions import FailRequest, InquireRequest, SkipRequest
-from connect.logger import function_log, LoggerAdapter
+from connect.logger import function_log
 from connect.models.activation_template_response import ActivationTemplateResponse
 from connect.models.activation_tile_response import ActivationTileResponse
 from connect.models.param import Param

--- a/connect/resources/tier_config_automation.py
+++ b/connect/resources/tier_config_automation.py
@@ -5,6 +5,7 @@
 
 from abc import ABCMeta
 import logging
+from typing import Optional
 
 from connect.exceptions import FailRequest, InquireRequest, SkipRequest
 from connect.logger import function_log, LoggerAdapter
@@ -36,7 +37,6 @@ class TierConfigAutomation(AutomationEngine):
     __metaclass__ = ABCMeta
     resource = 'tier/config-requests'
     model_class = TierConfigRequest
-    logger = LoggerAdapter(logging.getLogger('Tier.logger'))
 
     def filters(self, status='pending', **kwargs):
         """ Returns the default set of filters for Tier Config request, plus any others that you
@@ -63,13 +63,10 @@ class TierConfigAutomation(AutomationEngine):
             filters['configuration.product.id'] = ','.join(self.config.products)
         return filters
 
-    @function_log(custom_logger=logger)
+    @function_log
     def dispatch(self, request):
         # type: (TierConfigRequest) -> str
         try:
-            self._set_custom_logger(request.id, request.configuration.id,
-                                    request.configuration.account.id)
-
             if self.config.products \
                     and request.configuration.product.id not in self.config.products:
                 return 'Invalid product'
@@ -108,12 +105,9 @@ class TierConfigAutomation(AutomationEngine):
                                 .format(request.id, ex))
             return ''
 
-        finally:
-            self._set_custom_logger()
-
         return ''
 
-    @function_log(custom_logger=logger)
+    @function_log
     def update_parameters(self, pk, params):
         """ Sends a list of Param objects to Connect for updating.
 
@@ -127,3 +121,11 @@ class TierConfigAutomation(AutomationEngine):
             path=pk,
             json={'params': mapped_params},
         )[0]
+
+    def _set_logger_prefix(self, request):
+        # type: (Optional[TierConfigRequest]) -> None
+        if request:
+            self.logger.prefix = request.id + ' - ' + request.configuration.id \
+                                 + ' - ' + request.configuration.account.id
+        else:
+            self.logger.prefix = ''

--- a/connect/resources/tier_config_automation.py
+++ b/connect/resources/tier_config_automation.py
@@ -124,7 +124,6 @@ class TierConfigAutomation(AutomationEngine):
     def _set_logger_prefix(self, request):
         # type: (Optional[TierConfigRequest]) -> None
         if request:
-            self.logger.prefix = request.id + ' - ' + request.configuration.id \
-                                 + ' - ' + request.configuration.account.id
+            self.logger.prefix = request.id + ' - ' + request.configuration.account.id
         else:
             self.logger.prefix = ''

--- a/connect/resources/usage_automation.py
+++ b/connect/resources/usage_automation.py
@@ -13,6 +13,7 @@ import requests
 from typing import List, Optional
 
 from connect.exceptions import FileCreationError, FileRetrievalError
+from connect.logger import LoggerAdapter
 from connect.models.usage_listing import UsageListing
 from connect.models.usage_file import UsageFile
 from connect.models.usage_record import UsageRecord
@@ -28,7 +29,7 @@ class UsageAutomation(AutomationEngine):
     __metaclass__ = ABCMeta
     resource = 'listings'
     model_class = UsageFile
-    logger = logging.getLogger('Usage.logger')
+    logger = LoggerAdapter(logging.getLogger('Usage.logger'))
 
     def filters(self, status='listed', **kwargs):
         """
@@ -72,6 +73,8 @@ class UsageAutomation(AutomationEngine):
                 'on Contract {} '.format(request.contract.id) +
                 'and provider {}({})'.format(request.provider.id, request.provider.name))
             return 'failure'
+        finally:
+            self._set_custom_logger()
 
         self.logger.info('Processing result for usage on listing {}: {}'
                          .format(request.product.id, result))

--- a/connect/resources/usage_automation.py
+++ b/connect/resources/usage_automation.py
@@ -4,7 +4,6 @@
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
 import json
-import logging
 from abc import ABCMeta
 from tempfile import NamedTemporaryFile
 
@@ -13,7 +12,6 @@ import requests
 from typing import List, Optional
 
 from connect.exceptions import FileCreationError, FileRetrievalError
-from connect.logger import LoggerAdapter
 from connect.models.usage_listing import UsageListing
 from connect.models.usage_file import UsageFile
 from connect.models.usage_record import UsageRecord

--- a/connect/resources/usage_file_automation.py
+++ b/connect/resources/usage_file_automation.py
@@ -5,7 +5,6 @@
 
 from abc import ABCMeta
 import json
-import logging
 from typing import Optional
 
 from connect.exceptions import SkipRequest, UsageFileAction

--- a/connect/resources/usage_file_automation.py
+++ b/connect/resources/usage_file_automation.py
@@ -3,9 +3,10 @@
 # This file is part of the Ingram Micro Cloud Blue Connect SDK.
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
+from abc import ABCMeta
 import json
 import logging
-from abc import ABCMeta
+from typing import Optional
 
 from connect.exceptions import SkipRequest, UsageFileAction
 from connect.models.base import BaseModel
@@ -22,7 +23,6 @@ class UsageFileAutomation(AutomationEngine):
     __metaclass__ = ABCMeta
     resource = 'usage/files'
     model_class = UsageFile
-    logger = logging.getLogger('UsageFile.logger')
 
     def filters(self, status='ready', **kwargs):
         """
@@ -38,9 +38,6 @@ class UsageFileAutomation(AutomationEngine):
 
     def dispatch(self, request):
         # type: (UsageFile) -> str
-
-        self._set_custom_logger(request.id, request.name)
-
         try:
             # Validate product
             if self.config.products \
@@ -72,9 +69,13 @@ class UsageFileAutomation(AutomationEngine):
         except SkipRequest:
             processing_result = 'skip'
 
-        finally:
-            self._set_custom_logger()
-
         self.logger.info('Finished processing of usage file with ID {} with result {}'
                          .format(request.id, processing_result))
         return processing_result
+
+    def _set_logger_prefix(self, request):
+        # type: (Optional[UsageFile]) -> None
+        if request:
+            self.logger.prefix = request.id + ' - ' + request.name
+        else:
+            self.logger.prefix = ''

--- a/connect/resources/usage_file_automation.py
+++ b/connect/resources/usage_file_automation.py
@@ -72,6 +72,9 @@ class UsageFileAutomation(AutomationEngine):
         except SkipRequest:
             processing_result = 'skip'
 
+        finally:
+            self._set_custom_logger()
+
         self.logger.info('Finished processing of usage file with ID {} with result {}'
                          .format(request.id, processing_result))
         return processing_result


### PR DESCRIPTION
In order to correctly show log messages in Azure Application Insights, with their request & asset ids, the way a message is formatted needs to change.

Previously, ids were directly prepended to format string in the logger formatter. This makes this information not being sent to Azure, since it only shows the %(message) field. Now, a LoggerAdapter is being used instead, which embeds the ids in the %(message) itself, so it is shown in Azure.