### PR TITLE
Cps 85 multithread logs

### DIFF
--- a/connect/logger/__init__.py
+++ b/connect/logger/__init__.py
@@ -3,12 +3,13 @@
 # This file is part of the Ingram Micro Cloud Blue Connect SDK.
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
-from .logger import function_log, logger, LoggerAdapter
+from .logger import function_log, logger, LoggerAdapter, LoggerAdapterObserver
 
 # TODO add auto settings for cloud platforms
 
 __all__ = [
     'function_log',
     'logger',
-    'LoggerAdapter'
+    'LoggerAdapter',
+    'LoggerAdapterObserver'
 ]

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -35,15 +35,17 @@ class LoggerAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         if self.observer:
             self.observer.on_begin_process(msg, kwargs)
-        if self.replace_handler:
-            handlers_copy = self.logger.handlers[:]
-            for handler in handlers_copy:
-                if isinstance(self.replace_handler, type(handler)):
-                    self.logger.removeHandler(handler)
-                    self.logger.addHandler(self.replace_handler)
-        msg, kwargs = super(LoggerAdapter, self).process(msg, kwargs)
-        if self.observer:
-            self.observer.on_end_process(msg, kwargs)
+        try:
+            if self.replace_handler:
+                handlers_copy = self.logger.handlers[:]
+                for handler in handlers_copy:
+                    if isinstance(self.replace_handler, type(handler)):
+                        self.logger.removeHandler(handler)
+                        self.logger.addHandler(self.replace_handler)
+            msg, kwargs = super(LoggerAdapter, self).process(msg, kwargs)
+        finally:
+            if self.observer:
+                self.observer.on_end_process(msg, kwargs)
         return (
             '%s %s' % (self.prefix, msg) if self.prefix else msg,
             kwargs

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -30,10 +30,11 @@ class LoggerAdapter(logging.LoggerAdapter):
         super(LoggerAdapter, self).__init__(logger_, extra or {})
         self.prefix = None
         self.replace_handler = None
-        self.observer = observer or LoggerAdapterObserver()
+        self.observer = observer
 
     def process(self, msg, kwargs):
-        self.observer.on_begin_process(msg, kwargs)
+        if self.observer:
+            self.observer.on_begin_process(msg, kwargs)
         if self.replace_handler:
             handlers_copy = self.logger.handlers[:]
             for handler in handlers_copy:
@@ -41,7 +42,8 @@ class LoggerAdapter(logging.LoggerAdapter):
                     self.logger.removeHandler(handler)
                     self.logger.addHandler(self.replace_handler)
         msg, kwargs = super(LoggerAdapter, self).process(msg, kwargs)
-        self.observer.on_end_process(msg, kwargs)
+        if self.observer:
+            self.observer.on_end_process(msg, kwargs)
         return (
             '%s %s' % (self.prefix, msg) if self.prefix else msg,
             kwargs

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -90,15 +90,6 @@ class LoggerAdapter(logging.LoggerAdapter):
             if self.observer:
                 self.observer.on_end_log(logging.CRITICAL, msg, *args, **kwargs)
 
-    def log(self, level, msg, *args, **kwargs):
-        if self.observer:
-            self.observer.on_begin_log(level, msg, *args, **kwargs)
-        try:
-            super(LoggerAdapter, self).log(level, msg, *args, **kwargs)
-        finally:
-            if self.observer:
-                self.observer.on_end_log(level, msg, *args, **kwargs)
-
     def setLevel(self, level):
         self.logger.setLevel(level)
 

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -94,7 +94,7 @@ class LoggerAdapter(logging.LoggerAdapter):
         if self.observer:
             self.observer.on_begin_log(level, msg, *args, **kwargs)
         try:
-            super(LoggerAdapter, self).log(msg, *args, **kwargs)
+            super(LoggerAdapter, self).log(level, msg, *args, **kwargs)
         finally:
             if self.observer:
                 self.observer.on_end_log(level, msg, *args, **kwargs)

--- a/connect/logger/logger.py
+++ b/connect/logger/logger.py
@@ -24,13 +24,13 @@ class LoggerAdapter(logging.LoggerAdapter):
         self.replace_handler = None
 
     def process(self, msg, kwargs):
-        msg, kwargs = super(LoggerAdapter, self).process(msg, kwargs)
         if self.replace_handler:
             handlers_copy = self.logger.handlers[:]
             for handler in handlers_copy:
-                if isinstance(handler, type(self.replace_handler)):
+                if isinstance(self.replace_handler, type(handler)):
                     self.logger.removeHandler(handler)
                     self.logger.addHandler(self.replace_handler)
+        msg, kwargs = super(LoggerAdapter, self).process(msg, kwargs)
         return (
             '%s %s' % (self.prefix, msg) if self.prefix else msg,
             kwargs

--- a/connect/resources/automation_engine.py
+++ b/connect/resources/automation_engine.py
@@ -29,12 +29,12 @@ class AutomationEngine(BaseResource):
     def process(self, filters=None):
         # # type: (Dict[str, Any]) -> None
         for request in self.list(filters):
-            self._set_current_request(request)
-            self.dispatch(request)
-            self._set_current_request(None)
+            logger = self._set_current_request(request)
+            self.dispatch(request, logger)
+        self._set_current_request(None)
 
-    def dispatch(self, request):
-        # type: (BaseModel) -> str
+    def dispatch(self, request, logger):
+        # type: (BaseModel, LoggerAdapter) -> str
         raise NotImplementedError('Please implement `{}.dispatch` method'
                                   .format(self.__class__.__name__))
 
@@ -72,9 +72,10 @@ class AutomationEngine(BaseResource):
         return self._logger_adapter
 
     def _set_current_request(self, request):
-        # type: (Optional[BaseModel]) -> None
+        # type: (Optional[BaseModel]) -> logging.LoggerAdapter
         self._current_request = request
         self._set_logger_prefix(request)
+        return self.logger
 
     def _set_logger_prefix(self, request):
         # type: (Optional[BaseModel]) -> None

--- a/connect/resources/fulfillment_automation.py
+++ b/connect/resources/fulfillment_automation.py
@@ -126,7 +126,7 @@ class FulfillmentAutomation(AutomationEngine):
 
         except Exception as ex:
             logger.warning('Skipping request {} because an exception was raised: {}'
-                                .format(request.id, ex))
+                           .format(request.id, ex))
             return ''
 
     def create_request(self, request):
@@ -190,7 +190,7 @@ class FulfillmentAutomation(AutomationEngine):
                 conversation.add_message(str(obj))
             except TypeError as ex:
                 logger.error('Error updating conversation for request {}: {}'
-                                  .format(request_id, ex))
+                             .format(request_id, ex))
 
     def _set_logger_prefix(self, request):
         # type: (Optional[AssetRequest]) -> None

--- a/connect/resources/tier_config_automation.py
+++ b/connect/resources/tier_config_automation.py
@@ -7,7 +7,7 @@ from abc import ABCMeta
 from typing import Optional
 
 from connect.exceptions import FailRequest, InquireRequest, SkipRequest
-from connect.logger import function_log
+from connect.logger import function_log, LoggerAdapter
 from connect.models.activation_template_response import ActivationTemplateResponse
 from connect.models.activation_tile_response import ActivationTileResponse
 from connect.models.param import Param
@@ -63,19 +63,19 @@ class TierConfigAutomation(AutomationEngine):
         return query
 
     @function_log
-    def dispatch(self, request):
-        # type: (TierConfigRequest) -> str
+    def dispatch(self, request, logger):
+        # type: (TierConfigRequest, LoggerAdapter) -> str
         try:
             if self.config.products \
                     and request.configuration.product.id not in self.config.products:
                 return 'Invalid product'
 
-            self.logger.info(
+            logger.info(
                 'Start tier config request process / ID request - {}'.format(request.id))
             result = self.process_request(request)
 
             if not result:
-                self.logger.info('Method `process_request` did not return result')
+                logger.info('Method `process_request` did not return result')
                 return ''
 
             params = {}
@@ -100,8 +100,8 @@ class TierConfigAutomation(AutomationEngine):
             raise
 
         except Exception as ex:
-            self.logger.warning('Skipping request {} because an exception was raised: {}'
-                                .format(request.id, ex))
+            logger.warning('Skipping request {} because an exception was raised: {}'
+                           .format(request.id, ex))
             return ''
 
         return ''

--- a/connect/resources/usage_automation.py
+++ b/connect/resources/usage_automation.py
@@ -72,14 +72,15 @@ class UsageAutomation(AutomationEngine):
             return 'failure'
 
         logger.info('Processing result for usage on listing {}: {}'
-                         .format(request.product.id, result))
+                    .format(request.product.id, result))
         return 'success'
 
     def get_usage_template(self, product, logger=None):
         """ Returns the template file contents for a specified product.
 
         :param Product product: Specific product.
-        :param Union[Logger,LoggerAdapter] logger: The logger to use, or `None` to use this UsageAutomation's logger.
+        :param Union[Logger,LoggerAdapter] logger: The logger to use,
+        or `None` to use this UsageAutomation's logger.
         :return: The template file contents.
         :rtype: bytes
         :raises FileRetrievalError: Raised if the file contents could not be retrieved.
@@ -103,7 +104,8 @@ class UsageAutomation(AutomationEngine):
 
         :param UsageFile usage_file: Usage file.
         :param list[UsageRecord] usage_records: Records.
-        :param Union[Logger,LoggerAdapter] logger: The logger to use, or `None` to use this UsageAutomation's logger.
+        :param Union[Logger,LoggerAdapter] logger: The logger to use,
+        or `None` to use this UsageAutomation's logger.
         :return: Usage file.
         :rtype: UsageFile
         :raises FileCreationError: Raised if creation or uploading of the file fails.

--- a/connect/resources/usage_file_automation.py
+++ b/connect/resources/usage_file_automation.py
@@ -70,7 +70,7 @@ class UsageFileAutomation(AutomationEngine):
             processing_result = 'skip'
 
         logger.info('Finished processing of usage file with ID {} with result {}'
-                         .format(request.id, processing_result))
+                    .format(request.id, processing_result))
         return processing_result
 
     def _set_logger_prefix(self, request):

--- a/connect/resources/usage_file_automation.py
+++ b/connect/resources/usage_file_automation.py
@@ -8,6 +8,7 @@ import json
 from typing import Optional
 
 from connect.exceptions import SkipRequest, UsageFileAction
+from connect.logger import LoggerAdapter
 from connect.models.base import BaseModel
 from connect.models.usage_file import UsageFile
 from .automation_engine import AutomationEngine
@@ -35,8 +36,8 @@ class UsageFileAutomation(AutomationEngine):
             query.in_('product_id', self.config.products)
         return query
 
-    def dispatch(self, request):
-        # type: (UsageFile) -> str
+    def dispatch(self, request, logger):
+        # type: (UsageFile, LoggerAdapter) -> str
         try:
             # Validate product
             if self.config.products \
@@ -44,7 +45,7 @@ class UsageFileAutomation(AutomationEngine):
                 return 'Invalid product'
 
             # Process request
-            self.logger.info(
+            logger.info(
                 'Start usage file request process / ID request - {}'.format(request.id))
             result = self.process_request(request)
 
@@ -52,7 +53,7 @@ class UsageFileAutomation(AutomationEngine):
             processing_result = 'UsageFileAutomation.process_request returned {} while ' \
                                 'is expected to raise UsageFileAction or SkipRequest exception' \
                 .format(str(result))
-            self.logger.warning(processing_result)
+            logger.warning(processing_result)
             raise UserWarning(processing_result)
 
         # Catch action
@@ -68,7 +69,7 @@ class UsageFileAutomation(AutomationEngine):
         except SkipRequest:
             processing_result = 'skip'
 
-        self.logger.info('Finished processing of usage file with ID {} with result {}'
+        logger.info('Finished processing of usage file with ID {} with result {}'
                          .format(request.id, processing_result))
         return processing_result
 


### PR DESCRIPTION
Some changes that will allow the SDK to log correctly in a multithreaded environment. Main changes are:

The Automation classes are using self.logger to access the logger, but that logger is bound to the Automation object used to process all requests. When running in a multithreaded environment, each request modifies the LoggerAdapter in self.logger to prefix the message with the request id. This means that all threads would write the request id given by the last thread that modified self.logger instead of their own id. This is fixed by storing self.logger in a local variable at the beginning of processing the request, so if another thread modifies self.logger, the local var used in the thread still has the correct one.

Another change is that I have added a LoggerAdapterObserver class. The LoggerAdapter instances used in self.logger now have an "observer" property, and this observer is being notified whenever a log message has started and ended writing. This observer can be used in a multithreaded processor, to make the automation classes act as observers, which lock access to the logging system to other threads when a message starts writing, and releasing the lock after they are finished. This is because the log writing process performed by the LoggerAdapter goes as follows:
- The correct log file is established for the current request.
- The message is written to all the handlers.
By adding a lock, be turn both steps into an atomic operation, something that is required to prevent race conditions and to ensure that the message is written to the correct file.