### PR TITLE
CPS-87: Accept list in Param.structured_value

### DIFF
--- a/connect/models/param.py
+++ b/connect/models/param.py
@@ -3,7 +3,7 @@
 # This file is part of the Ingram Micro Cloud Blue Connect SDK.
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from .base import BaseModel
 from .constraints import Constraints
@@ -48,7 +48,7 @@ class Param(BaseModel):
     value_choices = None  # type: Optional[List[ValueChoice]]
     """ (List[str]|None) Available dropdown choices for parameter. """
 
-    structured_value = None  # type: Optional[dict]
+    structured_value = None  # type: Optional[Union[dict,list]]
 
     phase = None  # type: Optional[str]
     """ (str|None) Param phase. """

--- a/connect/models/schemas.py
+++ b/connect/models/schemas.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2019-2020 Ingram Micro. All Rights Reserved.
 
 from deprecation import deprecated
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, ValidationError
 import six
 
 
@@ -315,6 +315,14 @@ class CountrySchema(BaseSchema):
         return Country(**data)
 
 
+class StructuredValueField(fields.Field):
+    def _deserialize(self, value, attr=None, data=None):
+        if isinstance(value, (dict, list)):
+            return value
+        else:
+            raise ValidationError('Field should be dict or list')
+
+
 class ParamSchema(BaseSchema):
     name = fields.Str()
     description = fields.Str()
@@ -326,7 +334,7 @@ class ParamSchema(BaseSchema):
     scope = fields.Str()
     constraints = fields.Nested(ConstraintsSchema)
     value_choices = fields.Nested(ValueChoiceSchema, many=True)
-    structured_value = fields.Dict()
+    structured_value = StructuredValueField()
     phase = fields.Str()
     reconciliation = fields.Bool()
     events = fields.Nested(EventsSchema)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -284,3 +284,17 @@ def test_filter_by_products(get_mock):
             'Authorization': 'ApiKey XXXX:YYYY'},
         timeout=300,
     )
+
+
+def test_deserialize_param_with_dict_structured_value():
+    param = Param.deserialize('{"structured_value": {"msg": "Hello, world"}}')
+    assert isinstance(param.structured_value, dict)
+    assert param.structured_value['msg'] == 'Hello, world'
+
+
+def test_deserialize_param_with_list_structured_value():
+    param = Param.deserialize('{"structured_value": ["a", "b"]}')
+    assert isinstance(param.structured_value, list)
+    assert len(param.structured_value) == 2
+    assert param.structured_value[0] == 'a'
+    assert param.structured_value[1] == 'b'


### PR DESCRIPTION
Fix for a bug causing that when an array is defined as the value for the "structured_value" field of a Param, Marshmallow is not capable of parsing the object as a Python list.

The fix causes Marshmallow to accept either type of value in this field, and also updates the type hint in the Param class accordingly.